### PR TITLE
Small update

### DIFF
--- a/src/components/clip.ts
+++ b/src/components/clip.ts
@@ -1,6 +1,6 @@
 import { IntersectionController } from '@lit-labs/observers/intersection-controller.js';
 import { Metrics } from '@maveio/metrics';
-import { css, html, LitElement, nothing } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 
@@ -219,9 +219,6 @@ export class Clip extends LitElement {
       ${this.embedController.render({
         // TODO: add loading state with loading player UI
         pending: this.renderPending,
-        error: (error: unknown) =>
-          // TODO: add error state with error player UI
-          html`<p>${error instanceof Error ? error.message : nothing}</p>`,
         complete: (data) => {
           this._embed = data as Embed;
           if (!data) return this.renderPending();

--- a/src/components/player.ts
+++ b/src/components/player.ts
@@ -4,7 +4,7 @@ import 'media-chrome/dist/experimental/media-captions-selectmenu.js';
 import { IntersectionController } from '@lit-labs/observers/intersection-controller.js';
 import { Metrics } from '@maveio/metrics';
 import Hls from 'hls.js';
-import { css, html, LitElement, nothing } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { styleMap } from 'lit-html/directives/style-map.js';
 import { property, query, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
@@ -590,8 +590,6 @@ export class Player extends LitElement {
         })}
       >
         ${this.embedController.render({
-          error: (error: unknown) =>
-            html`<p>${error instanceof Error ? error.message : nothing}</p>`,
           complete: (data) => {
             if (!this._embed) {
               this._embed = data as Embed;

--- a/src/components/player.ts
+++ b/src/components/player.ts
@@ -47,7 +47,7 @@ export class Player extends LitElement {
   @property() subtitles?: string | [string];
   @property({ attribute: 'active-subtitle' }) active_subtitle?: string;
   @property() height?: string;
-  @property() autoplay?: 'always' | 'lazy';
+  @property() autoplay?: 'always' | 'lazy' | 'true';
   @property() controls?: 'full' | 'big' | 'none';
   @property() color?: string;
   @property() opacity?: string;
@@ -397,7 +397,7 @@ export class Player extends LitElement {
 
     if (
       this._embed &&
-      (this.autoplay == 'lazy' || this._embed.settings.autoplay == 'on_show')
+      ((this.autoplay === 'lazy' || this.autoplay === 'true') || this._embed.settings.autoplay == 'on_show')
     ) {
       if (this._intersected) {
         if (this._videoElement?.paused) {


### PR DESCRIPTION
- `<mave-clip>` shows a thumbnail when you have set Safari to never allow autoplay:
<img width="230" alt="Screenshot 2023-11-21 at 14 13 27" src="https://github.com/maveio/components/assets/238946/50da4143-cb4c-467f-b7f7-17b682bcb6ff">

- Remove `Failed to fetch {embed id}` message when something fails, just show in the log
- `autoplay="true"` also works, as it is used for video and this uses `lazy`
