### PR TITLE
First version of mave-transcript

### DIFF
--- a/src/components/transcript.ts
+++ b/src/components/transcript.ts
@@ -1,0 +1,155 @@
+import { css, html, LitElement, nothing } from 'lit';
+import { styleMap } from 'lit-html/directives/style-map.js';
+import { property, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { Caption } from '../embed/api';
+import { CaptionController } from '../embed/caption';
+import { Player } from './player';
+
+export class Transcript extends LitElement {
+  private _embedId: string;
+  @property()
+  get embed(): string {
+    return this._embedId;
+  }
+  set embed(value: string) {
+    if (this._embedId != value) {
+      this._embedId = value;
+      this.captionController = new CaptionController(this, this.embed);
+      this.requestUpdate('embed');
+    }
+  }
+
+  @property() highlight: string;
+
+  private _clickable: boolean = true;
+  @property()
+  get clickable(): boolean {
+    return this._clickable;
+  }
+  set clickable(value) {
+    if (this._clickable != value) {
+      if (typeof value === 'string') {
+        this._clickable = value === 'true';
+      } else {
+        this._clickable = value;
+      }
+      this.requestUpdate('clickable');
+    }
+  }
+
+
+  private captionController: CaptionController;
+  private player: Player;
+  private loop: boolean;
+
+  @state()
+  private currentTime: number = 0;
+
+  static styles = css`
+    :host {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    [part=word] {
+      background-color: rgba(255, 210, 42, 0.5);
+    }
+  `;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    const player = document.querySelector(`mave-player[embed="${this.embed}"]`) as Player;
+    if (player) {
+      this.player = player;
+
+      player.addEventListener('play', () => {
+        this.loop = true;
+        this.loopUpdateTime();
+      })
+      player.addEventListener('pause', () => {
+        this.loop = false;
+      })
+    }
+  }
+
+  updateTime() {
+    this.currentTime = this.player.currentTime;
+  }
+
+  loopUpdateTime() {
+    this.updateTime();
+    setTimeout(() => {
+      if (this.loop) {
+        requestAnimationFrame(this.loopUpdateTime.bind(this))
+      }
+    }, 10);
+  }
+
+  #jumpToSegment(event: Event) {
+    if (this.clickable) {
+      const segment = (event.target as HTMLElement).closest('p');
+      if (segment && this.player) {
+        const time = segment.getAttribute('x-caption-segment-start');
+        this.player.currentTime = Number(time);
+        if (this.player.paused) this.player.play();
+      }
+    }
+  }
+
+  inRange({ start, end }: { start: number, end: number }, part?: string) {
+    const withinValue = this.currentTime >= start && this.currentTime <= end;
+    if (withinValue) {
+      return part ? part : true;
+    } else {
+      return undefined;
+    }
+  }
+
+  segmentStyle() {
+    if (!this.clickable) return {};
+    return {
+      'cursor': 'pointer'
+    }
+  }
+
+  wordStyle(inRange: boolean) {
+    if (!inRange) return {};
+    return {
+      'background-color': this.highlight,
+    }
+  }
+
+  render() {
+    return this.captionController.render({
+      complete: (data) => {
+        const caption = data as Caption;
+
+        return html`
+          <div>
+            ${caption.segments.map((segment) => html`
+              <p style=${styleMap(this.segmentStyle())} @click=${this.clickable ? this.#jumpToSegment : nothing} part=${ifDefined(this.inRange(segment, 'segment'))} x-caption-segment-start="${segment.start}" x-caption-segment-end="${segment.end}">
+                ${segment.words.map((word) => html`
+                  <span style=${styleMap(this.wordStyle(this.inRange(word) as boolean))} part=${ifDefined(this.inRange(word, 'word'))} x-caption-word-start="${word.start}" x-caption-word-end="${word.end}">${word.word.trim()}</span>
+                `)}
+              </p>
+            `)}
+          </div>
+        `;
+      }
+    })
+  }
+}
+
+if (window && window.customElements) {
+  if (!window.customElements.get('mave-transcript')) {
+    window.customElements.define('mave-transcript', Transcript);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'mave-transcript': Transcript;
+  }
+}

--- a/src/embed/api.ts
+++ b/src/embed/api.ts
@@ -57,4 +57,22 @@ export type Collection = {
   embeds: Embed[];
 };
 
+export type Word = {
+  start: number;
+  end: number;
+  word: string;
+}
+
+export type Segment = {
+  text: string;
+  start: number;
+  end: number;
+  words: Word[];
+}
+
+export type Caption = {
+  text: string;
+  segments: Segment[];
+}
+
 export const baseUrl = '__MAVE_ENDPOINT__';

--- a/src/embed/caption.ts
+++ b/src/embed/caption.ts
@@ -1,0 +1,134 @@
+import { StatusRenderer, Task } from '@lit-labs/task';
+import { ReactiveControllerHost } from 'lit';
+
+import * as API from './api';
+
+export class CaptionController {
+  host: ReactiveControllerHost;
+  private task: Task;
+  private _embed: string;
+  private _token: string;
+  private _version: number;
+
+  constructor(host: ReactiveControllerHost, embed: string) {
+    this.host = host;
+    this.embed = embed;
+
+    this.task = new Task(
+      this.host,
+      async () => {
+        try {
+          const url = this.embedFile('subtitle.json');
+
+          const response = await fetch(url);
+          const data = await response.json();
+
+          // create sentences based on ., !, ?
+
+          // Regular expression to split the text while handling common cases
+          const regex = /(?<!\bwww\.\S+)(?<!@\S+)(?<!\.\d)(?<=[.!?])\s+/g;
+
+          // Split the text using the regular expression
+          const sentences = data.text.trim().split(regex);
+          const words = data.segments.flatMap((segment: API.Segment) => segment.words).map((word: API.Word) => {
+            return {
+              start: word.start,
+              end: word.end,
+              word: word.word.trim()
+            }
+          });
+
+          // create segments based on sentences
+          let currentWordIndex = 0;
+          const segments = sentences.map((sentence: String) => {
+
+            // grab last word from sentence
+            const lastWord = sentence.split(' ').pop();
+
+            // go through words from currentWordIndex and use the sentence until you have completed the sentence
+            const possibleWordCount = sentence.split(' ').length;
+            const possibleWords = words.slice(currentWordIndex, currentWordIndex + possibleWordCount + 10);
+
+            const lastWordIndex = possibleWords.findIndex((word: API.Word) => word.word == lastWord) + 1;
+
+            const sentenceWords = words.slice(currentWordIndex, currentWordIndex + lastWordIndex);
+
+            currentWordIndex += lastWordIndex;
+            return {
+              start: sentenceWords[0].start,
+              end: sentenceWords[sentenceWords.length - 1].end,
+              text: sentence,
+              words: sentenceWords
+            }
+          })
+
+
+          return { text: data.text, segments: segments } as Partial<API.Caption>;
+        } catch (e) {
+          console.log(e);
+          throw new Error(`Failed to fetch language file for "${this.embed}"`);
+        }
+      },
+      () => [this.embed],
+    );
+  }
+
+  set embed(value: string) {
+    if (this._embed != value) {
+      this._embed = value;
+      this.host.requestUpdate();
+    }
+  }
+
+  get embed() {
+    return this._embed;
+  }
+
+  set token(value: string) {
+    if (this._token != value) {
+      this._token = value;
+      this.host.requestUpdate();
+    }
+  }
+
+  get token() {
+    return this._token;
+  }
+
+  get spaceId(): string {
+    return this.embed.substring(0, 5);
+  }
+
+  get embedId(): string {
+    return this.embed.substring(5, this.embed.length);
+  }
+
+  get version(): string {
+    if (this._version) {
+      return `/v${this._version}/`;
+    }
+    return '/'
+  }
+
+  set version(value: number) {
+    if (this._version != value) {
+      this._version = value;
+      this.host.requestUpdate();
+    }
+  }
+
+  get cdnRoot(): string {
+    return `https://space-${this.spaceId}.video-dns.com`;
+  }
+
+  embedFile(file: string, params = new URLSearchParams()): string {
+    const url = new URL(`${this.cdnRoot}/${this.embedId}${file == 'manifest' ? '/' : this.version}${file}`);
+    if (this.token) params.append('token', this.token);
+    url.search = params.toString();
+    return url.toString();
+  }
+
+  render(renderFunctions: StatusRenderer<unknown>) {
+    return this.task?.render(renderFunctions);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,7 @@
 export { Clip } from './components/clip.js';
 export { Image } from './components/img.js';
 export { List } from './components/list.js';
+export { Player } from './components/player.js';
+export { Transcript } from './components/transcript.js';
 export { Upload } from './components/upload.js';
-export { Player };
 
-import { Pop } from './components/pop.js';
-
-import { Player } from './components/player.js';


### PR DESCRIPTION
```html 
<mave-transcript embed="{embed id}"></mave-transcript>
```
Results in the transcription as element, which you can show alongside your `<mave-player>`. If you combine the two, it will automatically connect to its play behaviour and highlight words once playing to indicate where you are. 

https://github.com/maveio/components/assets/238946/8fb710fd-d084-4f6f-9d95-5365de5b4512

By default you can also click on sentences to allow users to jump to a specific part of the video using the text. To disable it, and change the highlight color, you can do the following:

```html 
<mave-transcript embed="{embed id}" highlight="red" clickable="false"></mave-transcript>
```

ps: this PR depends on the API to provide a `subtitle.json`.


