### PR TITLE
Pop customization and small tweaks

### DIFF
--- a/src/components/player.ts
+++ b/src/components/player.ts
@@ -113,6 +113,7 @@ export class Player extends LitElement {
   @query("slot[name='start-screen']") startScreenElement: HTMLElement;
 
   private _startedPlaying = false;
+  private _themeLoaded = false;
 
   private _subtitlesText: HTMLElement;
 
@@ -247,13 +248,20 @@ export class Player extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
     this.hls.on(Hls.Events.LEVEL_LOADED, this.#handleQualityChange.bind(this));
-    ThemeLoader.get(this.theme, `${this.embedController.cdnRoot}/themes/player`);
+    this.loadTheme();
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     if (this._metrics) {
       this._metrics.demonitor();
+    }
+  }
+
+  loadTheme() {
+    if (this.embed && !this._themeLoaded) {
+      ThemeLoader.get(this.theme, `${this.embedController.cdnRoot}/themes/player`);
+      this._themeLoaded = true;
     }
   }
 
@@ -564,7 +572,7 @@ export class Player extends LitElement {
   get #subtitles() {
     if (this._embed.subtitles.length > 0) {
       return this._embed.subtitles.map((track) => {
-        if (this.subtitles && this.subtitles.includes(track.language)) {
+        if ((this.subtitles && this.subtitles.includes(track.language)) || (this.active_subtitle && this.active_subtitle == track.language) || this.subtitles == "all") {
           return html`
             <track mode="hidden" @cuechange=${this.#cuechange} label=${
             track.label
@@ -584,6 +592,7 @@ export class Player extends LitElement {
   }
 
   render() {
+    if (!this.embed) return;
     const startScreen = this.querySelector('[slot="start-screen"]') as HTMLElement;
     return html`
       <slot

--- a/src/components/pop.ts
+++ b/src/components/pop.ts
@@ -16,10 +16,11 @@ export class Pop extends LitElement {
   static styles = css`
     :host {
       all: initial;
-    }
-
-    :root {
       --backdrop: black;
+      --frame-max-height: 100vh;
+      --frame-ratio-w: 16;
+      --frame-ratio-h: 9;
+      --backdrop-filter: blur(0);
     }
 
     slot {
@@ -55,6 +56,7 @@ export class Pop extends LitElement {
     .backdrop {
       position: fixed;
       background: var(--backdrop);
+      backdrop-filter: var(--backdrop-filter);
       opacity: 0;
       top: 0;
       left: 0;
@@ -114,9 +116,6 @@ export class Pop extends LitElement {
       display: flex;
       align-items: center;
       justify-content: center;
-      --frame-max-height: 100vh;
-      --frame-ratio-w: 16;
-      --frame-ratio-h: 9;
       width: 100%;
       height: 100%;
       max-width: 100vw;
@@ -149,19 +148,38 @@ export class Pop extends LitElement {
     }
   }
 
+  private _backdropFilter: string;
+  @property({ attribute: 'backdrop-filter' })
+  get backdropFilter(): string {
+    const backdrop = this._backdropFilter;
+    return backdrop;
+  }
+  set backdropFilter(value: string) {
+    if (this._backdropFilter != value) {
+      this._backdropFilter = value;
+    }
+  }
+
   get styles() {
+    console.log(this.backdropFilter)
     const style = {
       '--backdrop': this.backdrop,
+      '--backdrop-filter': this.backdropFilter,
     };
     return styleMap(style);
   }
 
   open(player: Player) {
     this._player = player;
+    if (player.aspect_ratio) {
+      const [w, h] = player.aspect_ratio.split('/');
+      this.style.setProperty('--frame-ratio-w', w);
+      this.style.setProperty('--frame-ratio-h', h);
+    }
+
     this.style.display = 'block';
 
     const tryToOpen = (resolve: (value: unknown) => void) => {
-      this._frame.style.backgroundImage = `url(${player.poster})`;
       this._frame.appendChild(player);
 
       setTimeout(() => {
@@ -281,7 +299,7 @@ export const checkPop = (element: HTMLElement | ShadowRoot | Document) => {
       return { pop: document.querySelector(`mave-pop[embed=${embed}]`)!, attributes };
     }
 
-    if (document.querySelector('mave-pop')) {
+    if (document.querySelector('mave-pop:not([embed])')) {
       const attributes = getAllAttributesAsObject(document.querySelector('mave-pop:not([embed]) > mave-player')!);
 
       return { pop: document.querySelector('mave-pop:not([embed])')!, attributes };

--- a/src/embed/controller.ts
+++ b/src/embed/controller.ts
@@ -25,7 +25,6 @@ export class EmbedController {
       async () => {
         try {
           if (this.type == EmbedType.Embed && !this.embed) {
-            console.warn('No embed attr provided for mave-player');
             return;
           }
           if (this.type == EmbedType.Collection && !this.token) {

--- a/src/themes/dolphin.ts
+++ b/src/themes/dolphin.ts
@@ -387,7 +387,7 @@ export function build(name, LitElement, html, css) {
                     <path
                       stroke-linecap="round"
                       stroke-linejoin="round"
-                      d="M7.5 3.75H6A2.25 2.25 0 003.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0120.25 6v1.5m0 9V18A2.25 2.25 0 0118 20.25h-1.5m-9 0H6A2.25 2.25 0 013.75 18v-1.5M15"
+                      d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5"
                     />
                   </svg>
                 </div>
@@ -402,7 +402,7 @@ export function build(name, LitElement, html, css) {
                     <path
                       stroke-linecap="round"
                       stroke-linejoin="round"
-                      d="M7.5 3.75H6A2.25 2.25 0 003.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0120.25 6v1.5m0 9V18A2.25 2.25 0 0118 20.25h-1.5m-9 0H6A2.25 2.25 0 013.75 18v-1.5M15"
+                      d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5"
                     />
                   </svg>
                 </div>

--- a/src/themes/synthwave.ts
+++ b/src/themes/synthwave.ts
@@ -405,7 +405,7 @@ export function build(name, LitElement, html, css) {
                   <path
                     stroke-linecap="round"
                     stroke-linejoin="round"
-                    d="M7.5 3.75H6A2.25 2.25 0 003.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0120.25 6v1.5m0 9V18A2.25 2.25 0 0118 20.25h-1.5m-9 0H6A2.25 2.25 0 013.75 18v-1.5M15"
+                    d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5"
                   />
                 </svg>
               </div>
@@ -420,7 +420,7 @@ export function build(name, LitElement, html, css) {
                   <path
                     stroke-linecap="round"
                     stroke-linejoin="round"
-                    d="M7.5 3.75H6A2.25 2.25 0 003.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0120.25 6v1.5m0 9V18A2.25 2.25 0 0118 20.25h-1.5m-9 0H6A2.25 2.25 0 013.75 18v-1.5M15"
+                    d="M7.5 3.75H6A2.25 2.25 0 0 0 3.75 6v1.5M16.5 3.75H18A2.25 2.25 0 0 1 20.25 6v1.5m0 9V18A2.25 2.25 0 0 1 18 20.25h-1.5m-9 0H6A2.25 2.25 0 0 1 3.75 18v-1.5"
                   />
                 </svg>
               </div>


### PR DESCRIPTION
- [x] Allow `subtitles="all"` on playerto show complete list of all subtitles available
- [x] Use of `active-subtitle` on player does not require `subtitles` to show the subtitle
- [x] New `mave-pop` element to customize the `x-mave-pop` output:

<img width="1305" alt="Screenshot 2024-01-02 at 15 28 25" src="https://github.com/maveio/components/assets/238946/2592182b-e274-40f0-ba4a-163702254cd4">

`mave-pop` accepts:
- `embed`: for which id this `mave-pop` should show
- `backdrop`: to set the color of the backdrop
- `backdrop-filter`: to set a filter like: `backdrop-filter="blur(2px)"`

The contents allows your own HTML (still very buggy), but also allows you to define a generic or specific `mave-player` to be added once popped. Meaning you can now set a theme, or subtitle on the player that is used inside of the `mave-pop`.

Example (as shown in screenshot), add the following on your page where `x-mave-pop` is defined:

```html
<mave-pop style="display: none;" backdrop="rgba(1,1,1,0.8)" backdrop-filter="blur(2px)" embed="ubg884WtCYmJVgr">
  <mave-player theme="dolphin" embed="ubg884WtCYmJVgr" subtitles="en" style="display: block; width: 100%; background: center / contain no-repeat url(https://space-ubg88.video-dns.com/4WtCYmJVgr/thumbnail.jpg); aspect-ratio: 16 / 9;"></mave-player>
</mave-pop>
```

