### PR TITLE
Use setConfig to set global options for components

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,0 +1,5 @@
+MAVE_ENDPOINT="http://localhost:3000/api/v1"
+MAVE_UPLOAD_ENDPOINT="http://localhost:1080/upload"
+MAVE_SOCKET_ENDPOINT="ws://localhost:3000/api/v1/socket"
+MAVE_METRICS_SOCKET_ENDPOINT="ws://localhost:3001/socket"
+MAVE_CDN_ENDPOINT="http://localhost:8080"

--- a/src/components/clip.ts
+++ b/src/components/clip.ts
@@ -9,6 +9,8 @@ import { Embed, Rendition, RenditionsByCodec } from '../embed/api';
 import { EmbedController } from '../embed/controller';
 import { videoEvents } from '../utils/video_events';
 
+import { Config } from '../config';
+
 
 interface Source {
   media?: number | undefined;
@@ -32,15 +34,6 @@ export class Clip extends LitElement {
 
   @property() autoplay?: 'always' | 'off' | 'true' | 'scroll' | 'lazy' = 'lazy';
   @property() quality = 'auto';
-
-  private _metrics: boolean = true;
-  @property()
-  set metrics(value: boolean | string) {
-    this._metrics = (value === '' || value == 'true' || value == true) ?? false;
-  }
-  get metrics(): boolean {
-    return this._metrics;
-  }
 
   private _loop: boolean;
   @property()
@@ -303,11 +296,11 @@ export class Clip extends LitElement {
       };
 
       Metrics.config = {
-        socketPath: '__MAVE_METRICS_SOCKET_ENDPOINT__',
+        socketPath: Config.metrics.socket,
         apiKey: this._embed.metrics_key,
       };
 
-      if(this.metrics) this._metricsInstance = new Metrics(this._videoElement, this.embed, metadata);
+      if(Config.metrics.enabled) this._metricsInstance = new Metrics(this._videoElement, this.embed, metadata);
     }
 
     if (this._queue.length) {

--- a/src/components/player.ts
+++ b/src/components/player.ts
@@ -15,6 +15,8 @@ import { EmbedController } from '../embed/controller';
 import { ThemeLoader } from '../themes/loader';
 import { videoEvents } from '../utils/video_events';
 
+import { Config } from '../config';
+
 export class Player extends LitElement {
   private _embedId: string;
   @property()
@@ -50,15 +52,6 @@ export class Player extends LitElement {
   @property() autoplay?: 'always' | 'lazy' | 'true';
   @property() color?: string;
   @property() opacity?: string;
-
-  private _metrics: boolean = true;
-  @property()
-  set metrics(value: boolean | string) {
-    this._metrics = (value === '' || value == 'true' || value == true) ?? false;
-  }
-  get metrics(): boolean {
-    return this._metrics;
-  }
 
   private _loop: boolean;
   @property()
@@ -352,7 +345,7 @@ export class Player extends LitElement {
       });
 
       Metrics.config = {
-        socketPath: '__MAVE_METRICS_SOCKET_ENDPOINT__',
+        socketPath: Config.metrics.socket,
         apiKey: this._embed.metrics_key,
       };
 
@@ -375,16 +368,16 @@ export class Player extends LitElement {
 
         this.hls?.loadSource(this.#hlsPath);
         this.hls?.attachMedia(this._videoElement);
-        if(this.metrics) this._metricsInstance = new Metrics(this.hls, this.embed, metadata);
+        if(Config.metrics.enabled) this._metricsInstance = new Metrics(this.hls, this.embed, metadata);
       } else if (
         this._videoElement.canPlayType('application/vnd.apple.mpegurl') &&
         this.#hlsPath
       ) {
         this._videoElement.src = this.#hlsPath;
-        if(this.metrics) this._metricsInstance = new Metrics(this._videoElement, this.embed, metadata);
+        if(Config.metrics.enabled) this._metricsInstance = new Metrics(this._videoElement, this.embed, metadata);
       } else {
         this._videoElement.src = this.#srcPath;
-        if(this.metrics) this._metricsInstance = new Metrics(this._videoElement, this.embed, metadata);
+        if(Config.metrics.enabled) this._metricsInstance = new Metrics(this._videoElement, this.embed, metadata);
       }
 
       if (this._queue.length) {

--- a/src/components/upload.ts
+++ b/src/components/upload.ts
@@ -6,6 +6,8 @@ import * as tus from 'tus-js-client';
 import Data from '../embed/socket';
 import { LanguageController, localized, msg } from '../utils/localization';
 
+import { Config } from '../config';
+
 interface ErrorMessage {
   message: string;
 }
@@ -136,7 +138,7 @@ export class Upload extends LitElement {
 
   upload(file: File) {
     const upload = new tus.Upload(file, {
-      endpoint: '__MAVE_UPLOAD_ENDPOINT__',
+      endpoint: Config.upload.endpoint,
       retryDelays: [0, 3000, 5000, 10000, 20000, 60000, 60000],
       metadata: {
         title: file.name,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,20 @@
+export const Config = {
+  metrics: {
+    enabled: true,
+    socket: '__MAVE_METRICS_SOCKET_ENDPOINT__',
+  },
+  upload: {
+    socket: '__MAVE_SOCKET_ENDPOINT__',
+    endpoint: '__MAVE_UPLOAD_ENDPOINT__',
+  },
+  api: {
+    endpoint: '__MAVE_ENDPOINT__',
+  },
+  cdn: {
+    endpoint: '__MAVE_CDN_ENDPOINT__',
+  }
+};
+
+export function setConfig(config: Partial<typeof Config>) {
+  Object.assign(Config, config);
+}

--- a/src/embed/api.ts
+++ b/src/embed/api.ts
@@ -1,3 +1,5 @@
+import { Config } from '../config';
+
 export type Rendition = {
   size: 'sd' | 'hd' | 'fhd' | 'qhd' | 'uhd';
   codec: 'h264' | 'hevc' | 'av1';
@@ -94,4 +96,4 @@ export type Caption = {
   segments: Segment[];
 };
 
-export const baseUrl = '__MAVE_ENDPOINT__';
+export const baseUrl = Config.api.endpoint;

--- a/src/embed/controller.ts
+++ b/src/embed/controller.ts
@@ -3,6 +3,8 @@ import { ReactiveControllerHost } from 'lit';
 
 import * as API from './api';
 
+import { Config } from '../config';
+
 export enum EmbedType {
   Collection,
   Embed,
@@ -106,7 +108,7 @@ export class EmbedController {
   }
 
   get cdnRoot(): string {
-    return `https://space-${this.spaceId}.video-dns.com`;
+    return Config.cdn.endpoint.replace('${this.spaceId}', this.spaceId);
   }
 
   embedFile(file: string, params = new URLSearchParams()): string {

--- a/src/embed/socket.ts
+++ b/src/embed/socket.ts
@@ -1,5 +1,7 @@
 import { Channel, Socket as Phoenix } from 'phoenix';
 
+import { Config } from '../config';
+
 interface EmbedChannel {
   token: string;
   channel: Channel;
@@ -20,9 +22,7 @@ export default class Socket {
       Socket.instance = new Socket();
 
       if (window) {
-        const socketUrl = '__MAVE_SOCKET_ENDPOINT__';
-
-        Socket.instance.socket = new Phoenix(socketUrl, {
+        Socket.instance.socket = new Phoenix(Config.upload.socket, {
           params: {
             token,
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export { List } from './components/list.js';
 export { Player } from './components/player.js';
 export { Text } from './components/text.js';
 export { Upload } from './components/upload.js';
+export { setConfig } from './config.js';
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
       __MAVE_METRICS_SOCKET_ENDPOINT__: isProduction
         ? 'wss://metrics.video-dns.com/socket'
         : process.env.MAVE_METRICS_SOCKET_ENDPOINT,
+      __MAVE_CDN_ENDPOINT__: isProduction ? 'https://space-${this.spaceId}.video-dns.com' : process.env.MAVE_CDN_ENDPOINT,
     }),
   ],
 });


### PR DESCRIPTION
```html
<script crossorigin type="module">
    import { Player, setConfig } from "//cdn.video-dns.com/npm/@maveio/components/+esm";
  
    setConfig({
      metrics: { enabled: false, socket: 'wss://custom_path' },
      upload: { endpoint: 'https://custom_upload_path', socket: 'wss://custom_upload_socket_path' },
      api: { endpoint: 'https://custom_api_path' },
      cdn: { endpoint: 'https://custom_cdn_path' }  
    });
</script>
```