### PR TITLE
Instead of calling play directly we should handle our intermediate method

### DIFF
--- a/src/components/player.ts
+++ b/src/components/player.ts
@@ -256,9 +256,9 @@ export class Player extends LitElement {
 
   play() {
     if (this._videoElement) {
-      this._videoElement.play();
+      this.#requestPlay();
     } else {
-      this._queue.push(() => this._videoElement?.play());
+      this._queue.push(() => this.#requestPlay());
     }
   }
 


### PR DESCRIPTION
Otherwise monitoring views for a `x-mave-pop` won't be called.