### PR TITLE
Use mave-pop with a list (token)

### DIFF
--- a/src/components/pop.ts
+++ b/src/components/pop.ts
@@ -206,6 +206,9 @@ export class Pop extends LitElement {
   _nextPreviousSet = false;
   _opened = false;
 
+  _touchStartX: number = 0;
+  _touchEndX: number = 0;
+
   connectedCallback() {
     super.connectedCallback();
     if (this.token) this.embedController.token = this.token;
@@ -223,6 +226,21 @@ export class Pop extends LitElement {
       if (e.key === 'ArrowRight' && index < this._collection.videos.length - 1) {
         this.playNextOrPrevious(1);
       } else if (e.key === 'ArrowLeft' && index > 0) {
+        this.playNextOrPrevious(-1);
+      }
+    }
+  }
+
+  handleSwipe() {
+    const swipeThreshold = 50; // Minimum distance in pixels for a swipe to be counted
+    const swipeDistance = this._touchStartX - this._touchEndX;
+
+    if (Math.abs(swipeDistance) > swipeThreshold) {
+      if (swipeDistance > 0) {
+        // Swipe left, go to the next video
+        this.playNextOrPrevious(1);
+      } else {
+        // Swipe right, go to the previous video
         this.playNextOrPrevious(-1);
       }
     }
@@ -358,6 +376,9 @@ export class Pop extends LitElement {
         { once: true },
       );
 
+      this.addEventListener('touchstart', this.touchStart.bind(this), { passive: true });
+      this.addEventListener('touchend', this.touchEnd.bind(this), { passive: true });
+
       this._opened = true;
 
       resolve(this._player);
@@ -376,6 +397,15 @@ export class Pop extends LitElement {
         tryToOpen(resolve);
       }
     });
+  }
+
+  touchStart(e: TouchEvent) {
+    this._touchStartX = e.touches[0].clientX;
+  }
+
+  touchEnd(e: TouchEvent) {
+    this._touchEndX = e.changedTouches[0].clientX;
+    this.handleSwipe();
   }
 
   possibleClose(e: MouseEvent) {
@@ -403,6 +433,9 @@ export class Pop extends LitElement {
       },
       { once: true },
     );
+
+    this.removeEventListener('touchstart', this.touchStart.bind(this));
+    this.removeEventListener('touchend', this.touchEnd.bind(this));
 
     this._opened = false;
   }

--- a/src/components/pop.ts
+++ b/src/components/pop.ts
@@ -1,8 +1,10 @@
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { query } from 'lit/decorators/query.js';
 
 import { property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import { Collection } from '../embed/api';
+import { EmbedController, EmbedType } from '../embed/controller';
 import { Player } from './player.js';
 
 export class Pop extends LitElement {
@@ -12,6 +14,8 @@ export class Pop extends LitElement {
   @query('.backdrop') _backdrop: HTMLElement;
 
   private _player?: Player;
+  private embedController = new EmbedController(this, EmbedType.Collection);
+  private _collection: Collection;
 
   static styles = css`
     :host {
@@ -139,6 +143,8 @@ export class Pop extends LitElement {
     }
   `;
 
+  @property() token?: string;
+
   private _backdropColor: string;
   @property()
   get backdrop(): string {
@@ -169,6 +175,11 @@ export class Pop extends LitElement {
       '--backdrop-filter': this.backdropFilter,
     };
     return styleMap(style);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.token) this.embedController.token = this.token;
   }
 
   open(player: Player) {
@@ -234,6 +245,15 @@ export class Pop extends LitElement {
 
   render() {
     return html`
+      ${this.token
+        ? this.embedController.render({
+            complete: (data: any) => {
+              this._collection = data as Collection;
+              if (data.error) return console.warn(data.error);
+            },
+          })
+        : nothing}
+
       <dialog style=${this.styles}>
         <div class="backdrop"></div>
         <div class="content" @click=${this.possibleClose}>

--- a/src/components/pop.ts
+++ b/src/components/pop.ts
@@ -92,6 +92,14 @@ export class Pop extends LitElement {
       display: block;
     }
 
+    dialog[closed] slot {
+      display: block;
+    }
+
+    dialog[open] slot {
+      display: block;
+    }
+
     .button-close {
       display: none;
       position: fixed;
@@ -140,6 +148,12 @@ export class Pop extends LitElement {
       background-size: contain;
       background-position: center center;
       background-repeat: no-repeat;
+    }
+
+    slot {
+      position: fixed;
+      color: white;
+      bottom: 10px;
     }
   `;
 
@@ -227,6 +241,7 @@ export class Pop extends LitElement {
   }
 
   possibleClose(e: MouseEvent) {
+    if (e.target instanceof HTMLElement && !e.target.closest('dialog')) return;
     if (e.target != this._player) this.close();
   }
 
@@ -258,7 +273,7 @@ export class Pop extends LitElement {
         <div class="backdrop"></div>
         <div class="content" @click=${this.possibleClose}>
           <div class="wrapper">
-            <slot style="display: none;"></slot>
+            <slot></slot>
             <div class="frame"></div>
           </div>
         </div>


### PR DESCRIPTION
This PR will add functionality to allow you to use a custom `<mave-pop token={jwt}></mave-pop>` to add a space or collection and use the pop as video slider:

You can add `[name="mave-pop-previous"]`,  `[name="mave-pop-next"]`,  `[name="mave-current-index"]` and `[name="mave-folder-count"]`.

Todo:

- [x] Mobile support (swipe)

Example:
<img width="840" alt="Screenshot 2024-12-13 at 17 59 58" src="https://github.com/user-attachments/assets/c5529eda-d4ad-400a-9246-fc1d2b000736" />

