### PR TITLE
fix: Removed cdn.jsdelivr.net from potential dist folder util

### DIFF
--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -1,7 +1,7 @@
 export const potentialDistFolder = () => {
   if (!document) return '';
   const host = new URL(import.meta.url).host;
-  if (['cdn.jsdelivr.net', 'cdn.mave.io', 'cdn.video-dns.com'].includes(host)) {
+  if (['cdn.mave.io', 'cdn.video-dns.com'].includes(host)) {
     return 'dist/';
   }
   return '';

--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -1,7 +1,7 @@
 export const potentialDistFolder = () => {
   if (!document) return '';
-  const host = new URL(import.meta.url).host;
-  if (['cdn.mave.io', 'cdn.video-dns.com'].includes(host)) {
+  const pathname = new URL(import.meta.url).pathname;
+  if (pathname.includes('+esm')) {
     return 'dist/';
   }
   return '';


### PR DESCRIPTION
When loading the player from jsdelivr, the theme resolution fails. The dist prefix is added while it already has one.

I'm using `https://cdn.jsdelivr.net/npm/@maveio/components@0.0.139/dist/components/player.min.js` to load the player.

![image](https://github.com/user-attachments/assets/e9f83494-75d9-4a79-b71c-dc8acd3c7a9d)
