### PR TITLE
Allow `configureMave()` to set config before loading package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@lit/localize": "^0.12.1",
         "@lit/react": "^1.0.5",
         "@lit/task": "^1.0.0",
-        "@maveio/data": "^0.1.0",
+        "@maveio/data": "^0.1.1",
         "hls.js": "^1.6.13",
         "lit": "^3.1.2",
         "media-chrome": "^4.15.0",
@@ -1780,13 +1780,10 @@
       }
     },
     "node_modules/@maveio/data": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@maveio/data/-/data-0.1.0.tgz",
-      "integrity": "sha512-kabdlukYLELb+X9JXc8dQMjtU5nz9qHNZupI7mLZezhskRgMqBmjauB9v5s0DBfZSktIrrgAE3lTWChGA4bYdQ==",
-      "license": "AGPL-3.0-only",
-      "engines": {
-        "node": ">=24.0.0"
-      }
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@maveio/data/-/data-0.1.1.tgz",
+      "integrity": "sha512-C/uHcfbBRjGKpqMzG2jg9glPB1g+JNkQCu44kxOsYmxRXg68zIi1QWq4yY0gPvRJ+wWERkjBrF+0Qe1/O87qlg==",
+      "license": "AGPL-3.0-only"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maveio/components",
-  "version": "0.0.172",
+  "version": "0.0.173",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maveio/components",
-      "version": "0.0.172",
+      "version": "0.0.173",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@lit-labs/observers": "^2.0.2",
@@ -2776,9 +2776,9 @@
       "license": "MIT"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9062,9 +9062,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@lit/localize": "^0.12.1",
     "@lit/react": "^1.0.5",
     "@lit/task": "^1.0.0",
-    "@maveio/data": "^0.1.0",
+    "@maveio/data": "^0.1.1",
     "hls.js": "^1.6.13",
     "lit": "^3.1.2",
     "media-chrome": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.cjs"
     },
+    "./config": {
+      "types": "./dist/config.d.ts",
+      "import": "./dist/config.js",
+      "default": "./dist/config.cjs"
+    },
     "./react": {
       "types": "./dist/react.d.ts",
       "import": "./dist/react.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-export const Config = {
+const defaultConfig = {
   metrics: {
     enabled: true,
     endpoint: '__MAVE_METRICS_ENDPOINT__',
@@ -15,6 +15,63 @@ export const Config = {
   },
 };
 
-export function setConfig(config: Partial<typeof Config>) {
-  Object.assign(Config, config);
+export type MaveConfig = typeof defaultConfig;
+
+type PartialMaveConfig = Partial<{
+  [K in keyof MaveConfig]: Partial<MaveConfig[K]>;
+}>;
+
+type MaveGlobal = typeof globalThis & {
+  __maveComponentsConfig?: PartialMaveConfig;
+};
+
+function mergeConfig(target: MaveConfig, config: PartialMaveConfig | undefined) {
+  if (!config) return target;
+
+  for (const [section, values] of Object.entries(config) as [
+    keyof MaveConfig,
+    Partial<MaveConfig[keyof MaveConfig]> | undefined,
+  ][]) {
+    if (!values) continue;
+    Object.assign(target[section], values);
+  }
+
+  return target;
 }
+
+function browserGlobal(): MaveGlobal | null {
+  if (typeof globalThis === 'undefined') return null;
+  return globalThis as MaveGlobal;
+}
+
+function readGlobalConfig(): PartialMaveConfig | undefined {
+  return browserGlobal()?.__maveComponentsConfig;
+}
+
+function writeGlobalConfig(config: MaveConfig) {
+  const globalObject = browserGlobal();
+  if (!globalObject) return;
+
+  globalObject.__maveComponentsConfig = {
+    api: { ...config.api },
+    cdn: { ...config.cdn },
+    metrics: { ...config.metrics },
+    upload: { ...config.upload },
+  };
+}
+
+export const Config: MaveConfig = {
+  api: { ...defaultConfig.api },
+  cdn: { ...defaultConfig.cdn },
+  metrics: { ...defaultConfig.metrics },
+  upload: { ...defaultConfig.upload },
+};
+
+mergeConfig(Config, readGlobalConfig());
+
+export function configureMave(config: PartialMaveConfig) {
+  mergeConfig(Config, config);
+  writeGlobalConfig(Config);
+}
+
+export const setConfig = configureMave;

--- a/src/embed/api.ts
+++ b/src/embed/api.ts
@@ -130,4 +130,6 @@ export type Caption = {
   segments: Segment[];
 };
 
-export const baseUrl = Config.api.endpoint;
+export function baseUrl() {
+  return Config.api.endpoint;
+}

--- a/src/embed/controller.ts
+++ b/src/embed/controller.ts
@@ -61,7 +61,7 @@ export class EmbedController {
     if (this.type == EmbedType.Embed) {
       return this.embedFile('manifest.json');
     } else {
-      const url = new URL(`${API.baseUrl}/collection/${this.token}`);
+      const url = new URL(`${API.baseUrl()}/collection/${this.token}`);
       if (this.embed && this.embed?.length > 1)
         url.searchParams.append('embed', this.embed);
       return url.toString();

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ export { Player } from './components/player.js';
 export { Pop } from './components/pop.js';
 export { Text } from './components/text.js';
 export { Upload } from './components/upload.js';
-export { setConfig } from './config.js';
+export { configureMave, setConfig } from './config.js';

--- a/src/react.ts
+++ b/src/react.ts
@@ -75,4 +75,4 @@ export const Pop = createComponent({
   react: React,
 });
 
-export { setConfig } from './config.js';
+export { configureMave, setConfig } from './config.js';

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -1,6 +1,8 @@
 import type { App, Ref, SetupContext, Slots, VNode } from 'vue';
 import { cloneVNode, defineComponent, h, onMounted, onUpdated, ref } from 'vue';
 
+export { configureMave, setConfig } from './config.js';
+
 import { Clip as ClipElement } from './components/clip.js';
 import { Files as FilesElement } from './components/files.js';
 import { Image as ImageElement } from './components/img.js';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,8 +10,7 @@ const isDev = process.env.NODE_ENV === 'development';
 
 export default defineConfig({
   platform: 'browser',
-  entry: ['src/**/*.ts'],
-  entryPoints: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/config.ts', 'src/react.ts', 'src/vue.ts'],
   format: ['esm', 'cjs'],
   splitting: true,
   treeshake: isProduction,


### PR DESCRIPTION
We initially had setConfig to allow for updating endpoints, which works in certain situations - but not all. This is now free of race conditions as the config file can directly be imported before the rest of the package (also the bundled `+esm` version) is loaded.