### PR TITLE
Support opt-in signed expiring media URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ Once you have uploaded your first video you can show your videos in different fo
 
 You can either change the settings through our interface or provide it as attributes. To learn which attributes you can use to change the appearance of your player, go to [our docs](https://docs.mave.io).
 
+#### Signed, expiring media URLs
+
+Signed delivery is opt-in. Request a media root from the authenticated Mave API and pass the returned `url` to the `signed-url` attribute together with the matching embed ID:
+
+```html
+<mave-player embed="{embed id}" signed-url="{signed media root}"></mave-player>
+```
+
+The component uses that root for the manifest, HLS playlists and segments, video renditions, posters, subtitles, and storyboards. The same attribute is supported by `<mave-clip>` and `<mave-text>`. Existing embeds without `signed-url` continue to use the public CDN.
+
 ### Clip
 
 ```html

--- a/src/components/clip.ts
+++ b/src/components/clip.ts
@@ -51,12 +51,14 @@ export class Clip extends LitElement {
   private _poster?: string;
   @property()
   get poster(): string | undefined {
-    return selectClipPosterSource({
+    const source = selectClipPosterSource({
       explicitPoster: this._poster,
       fallback: this.fallback,
       poster: this._embed?.poster,
       toSrc: (file) => this.embedController.embedFile(file),
     });
+
+    return this.embedController.authorizeUrl(source) ?? undefined;
   }
   set poster(value: string | null) {
     if (value) {
@@ -76,6 +78,19 @@ export class Clip extends LitElement {
       this._token = value;
       this.requestUpdate('token');
       this.embedController.token = this._token;
+    }
+  }
+
+  private _signedUrl: string;
+  @property({ attribute: 'signed-url' })
+  get signedUrl(): string {
+    return this._signedUrl;
+  }
+  set signedUrl(value: string) {
+    if (this._signedUrl != value) {
+      this._signedUrl = value;
+      this.requestUpdate('signedUrl');
+      this.embedController.signedUrl = value;
     }
   }
 

--- a/src/components/player.ts
+++ b/src/components/player.ts
@@ -110,6 +110,21 @@ export class Player extends MaveElement {
     }
   }
 
+  private _signedUrl: string;
+  @property({ attribute: 'signed-url' })
+  get signedUrl(): string {
+    return this._signedUrl;
+  }
+  set signedUrl(value: string) {
+    if (this._signedUrl != value) {
+      this.#resetDeferredMediaLoadState();
+      this._signedUrl = value;
+      this.requestUpdate('signedUrl');
+      this.embedController.signedUrl = value;
+      this.#queueMediaLoadSync();
+    }
+  }
+
   @property() locale?: string;
 
   @property({ attribute: 'aspect-ratio' }) aspect_ratio?: string;
@@ -1286,9 +1301,11 @@ export class Player extends MaveElement {
 
   #manifestPoster() {
     return (
-      this._embedObj?.poster?.image_src ||
-      this._embedObj?.poster?.initial_frame_src ||
-      null
+      this.embedController.authorizeUrl(
+        this._embedObj?.poster?.image_src ||
+          this._embedObj?.poster?.initial_frame_src ||
+          null,
+      ) ?? null
     );
   }
 
@@ -2898,7 +2915,7 @@ export class Player extends MaveElement {
       ? this.embedController.embedFile(`h264_${highestRendition?.size}.mp4`)
       : this._embedObj.video.original;
 
-    return src;
+    return this.embedController.authorizeUrl(src);
   }
 
   get #subtitles() {
@@ -2927,7 +2944,9 @@ export class Player extends MaveElement {
           return html`
             <track mode="hidden" @cuechange=${this.#cuechange} label=${
             track.label
-          } kind="subtitles" srclang=${track.language} src=${track.path}></track>
+          } kind="subtitles" srclang=${
+            track.language
+          } src=${this.embedController.authorizeUrl(track.path)}></track>
           `;
         }
       });

--- a/src/components/text.ts
+++ b/src/components/text.ts
@@ -23,8 +23,22 @@ export class Text extends LitElement {
     if (this._embedId != value) {
       this._embedId = value;
       this.captionController = new CaptionController(this, this.embed);
+      this.captionController.signedUrl = this._signedUrl;
       this.reset();
       this.requestUpdate('embed');
+    }
+  }
+
+  private _signedUrl: string;
+  @property({ attribute: 'signed-url' })
+  get signedUrl(): string {
+    return this._signedUrl;
+  }
+  set signedUrl(value: string) {
+    if (this._signedUrl != value) {
+      this._signedUrl = value;
+      this.requestUpdate('signedUrl');
+      if (this.captionController) this.captionController.signedUrl = value;
     }
   }
 

--- a/src/embed/caption.ts
+++ b/src/embed/caption.ts
@@ -40,6 +40,7 @@ export class CaptionController {
   private task: Task;
   private _embed: string;
   private _token: string;
+  private _signedUrl: string;
   private _version: number;
 
   constructor(host: ReactiveControllerHost, embed: string) {
@@ -162,7 +163,7 @@ export class CaptionController {
           throw new Error();
         }
       },
-      () => [this.embed],
+      () => [this.embed, this.token, this.signedUrl],
     );
   }
 
@@ -186,6 +187,17 @@ export class CaptionController {
 
   get token() {
     return this._token;
+  }
+
+  set signedUrl(value: string) {
+    if (this._signedUrl != value) {
+      this._signedUrl = value;
+      this.host.requestUpdate();
+    }
+  }
+
+  get signedUrl() {
+    return this._signedUrl;
   }
 
   get spaceId(): string {
@@ -214,14 +226,19 @@ export class CaptionController {
     return Config.cdn.endpoint.replace('${this.spaceId}', this.spaceId);
   }
 
+  get mediaRoot(): string {
+    return this.signedUrl || `${this.cdnRoot}/${this.embedId}`;
+  }
+
   embedFile(file: string, params = new URLSearchParams()): string {
-    const url = new URL(
-      `${this.cdnRoot}/${this.embedId}${
-        file == 'manifest.json' ? '/' : this.version
-      }${file}`,
-    );
-    if (this.token) params.append('token', this.token);
-    url.search = params.toString();
+    const url = new URL(this.mediaRoot);
+    const versionPath = file == 'manifest.json' ? '' : this.version;
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/${`${versionPath}${file}`.replace(
+      /^\//,
+      '',
+    )}`;
+    if (this.token) params.set('token', this.token);
+    params.forEach((value, key) => url.searchParams.set(key, value));
     return url.toString();
   }
 

--- a/src/embed/controller.ts
+++ b/src/embed/controller.ts
@@ -20,6 +20,7 @@ export class EmbedController {
   private type: EmbedType;
   private _embed: string;
   private _token: string;
+  private _signedUrl: string;
   private _version: number;
   private _enabled: boolean;
   private _embedData: Partial<API.Embed>;
@@ -54,9 +55,15 @@ export class EmbedController {
 
           const requestEmbed = this.embed;
           const requestToken = this.token;
+          const requestSignedUrl = this.signedUrl;
           const data = await this.fetchManifestWithRetry(() => {
             if (!this.enabled) return;
-            if (this.embed !== requestEmbed || this.token !== requestToken) return;
+            if (
+              this.embed !== requestEmbed ||
+              this.token !== requestToken ||
+              this.signedUrl !== requestSignedUrl
+            )
+              return;
 
             return this.manifest_url;
           });
@@ -77,7 +84,7 @@ export class EmbedController {
           throw new Error(`Failed to fetch "${this.embed}"`);
         }
       },
-      () => [this.embed, this.token, this.enabled],
+      () => [this.embed, this.token, this.signedUrl, this.enabled],
     );
   }
 
@@ -181,6 +188,18 @@ export class EmbedController {
     return this._token;
   }
 
+  set signedUrl(value: string) {
+    if (this._signedUrl != value) {
+      this._signedUrl = value;
+      this.loading = true;
+      this.host.requestUpdate();
+    }
+  }
+
+  get signedUrl() {
+    return this._signedUrl;
+  }
+
   set enabled(value: boolean) {
     if (this._enabled != value) {
       this._enabled = value;
@@ -219,6 +238,10 @@ export class EmbedController {
     return Config.cdn.endpoint.replace('${this.spaceId}', this.spaceId);
   }
 
+  get mediaRoot(): string {
+    return this.signedUrl || `${this.cdnRoot}/${this.embedId}`;
+  }
+
   refresh(): Promise<unknown> {
     this.enabled = true;
     this.loading = true;
@@ -226,33 +249,54 @@ export class EmbedController {
   }
 
   embedFile(file: string, params = new URLSearchParams()): string {
-    const url = new URL(
-      `${this.cdnRoot}/${this.embedId}${
-        file == 'manifest.json' ? '/' : this.version
-      }${file}`,
-    );
+    const parsedFile = new URL(file, 'https://media.invalid/');
+    const versionPath = file.split('?')[0] == 'manifest.json' ? '' : this.version;
+    const url = this.mediaUrl(`${versionPath}${parsedFile.pathname.slice(1)}`);
 
-    if (file.includes('?')) {
-      const [_file, query] = file.split('?');
-      const query_params = new URLSearchParams(query);
-      query_params.forEach((value, key) => {
-        params.append(key, value);
-      });
-    }
-
-    if (this.token) params.append('token', this.token);
+    parsedFile.searchParams.forEach((value, key) => params.set(key, value));
+    if (this.token) params.set('token', this.token);
     if (file == 'manifest.json') {
       if (params.has('e')) params.delete('e');
-      params.append('e', new Date().getTime().toString());
+      params.set('e', new Date().getTime().toString());
     }
     if (file !== 'manifest.json' && !this.caching) {
       // const e = !this.caching ? new Date() : new Date(this._embedData.created_at);
       if (!params.has('e')) {
-        params.append('e', new Date().getTime().toString());
+        params.set('e', new Date().getTime().toString());
       }
     }
-    url.search = params.toString();
+
+    params.forEach((value, key) => url.searchParams.set(key, value));
     return url.toString();
+  }
+
+  authorizeUrl(source: string | null | undefined): string | null | undefined {
+    if (!source || !this.signedUrl) return source;
+
+    try {
+      const publicUrl = new URL(source);
+      const embedMarker = `/${this.embedId}/`;
+      const markerIndex = publicUrl.pathname.indexOf(embedMarker);
+      if (markerIndex < 0) return source;
+
+      const relativePath = publicUrl.pathname.slice(markerIndex + embedMarker.length);
+      const signedUrl = this.mediaUrl(relativePath);
+      publicUrl.searchParams.forEach((value, key) =>
+        signedUrl.searchParams.set(key, value),
+      );
+      return signedUrl.toString();
+    } catch {
+      return source;
+    }
+  }
+
+  private mediaUrl(relativePath: string): URL {
+    const url = new URL(this.mediaRoot);
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/${relativePath.replace(
+      /^\//,
+      '',
+    )}`;
+    return url;
   }
 
   render(renderFunctions: StatusRenderer<unknown>) {


### PR DESCRIPTION
## Summary
- add an opt-in `signed-url` attribute to `<mave-player>`, `<mave-clip>`, and `<mave-text>`
- resolve manifests, HLS media, renditions, posters, subtitles, and storyboards below the signed media root
- preserve existing public CDN behavior when the attribute is absent

## Verification
- TypeScript typecheck
- tsup ESM, CJS, and declaration build

Related Core and Infrastructure changes use the same `feature/signed-expiring-media-urls` branch.

## Release order
1. Deploy [Infrastructure #4](https://github.com/maveio/infrastructure/pull/4) first. This adds the runtime values and removes the API cache stage; the previous Core release safely ignores the new environment variables.
2. Deploy [Core #11](https://github.com/maveio/core/pull/11). Smoke-test signed-root issuance, playlist delivery, and the Object Storage redirect before continuing.
3. Publish [Components #125](https://github.com/maveio/components/pull/125) last. Consumers can then opt in with `signed-url`; embeds without it remain unchanged.

Rollback in reverse order: Components, Core, then Infrastructure.
